### PR TITLE
mudando nome da classe teste para testes (migration)

### DIFF
--- a/db/migrate/20201023194855_testes.rb
+++ b/db/migrate/20201023194855_testes.rb
@@ -1,4 +1,4 @@
-class Teste < ActiveRecord::Migration[6.0]
+class Testes < ActiveRecord::Migration[6.0]
   def change
     create_table :testes  do |t|
       t.string :nome

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_27_000010) do
+ActiveRecord::Schema.define(version: 2020_10_26_190724) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
estava dando erro porque ja existia uma classe teste (se nao me engano), entao para poder rodar db:migrate tive que mudar o nome da classe de migration.